### PR TITLE
Change Travis Python version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: python
 python:
-  - "3.5"
+  - "3.6"
 
 before_install:
   - docker build -t bionitio-boot boot/


### PR DESCRIPTION
The build on the bionitio repo is failing because we're trying to import a version of Biopython that relies on Python 3.6, but are testing under 3.5. Bumping version to 3.6 allows build to pass on my fork. Note that the bionitio-python repo isn't experiencing the same issue, I think because biopython version is pinned.